### PR TITLE
Section 3.2p1

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<title></title>
 	<meta name="generator" content="LibreOffice 7.3.7.2 (Linux)"/>
 	<meta name="created" content="2023-01-23T23:54:33.935675256"/>
-	<meta name="changed" content="2023-01-24T23:19:36.466580865"/>
+	<meta name="changed" content="2023-01-24T23:48:26.258382601"/>
 	<style type="text/css">
 		@page { size: 21cm 29.7cm; margin: 2cm }
 		p { line-height: 115%; margin-bottom: 0.25cm; background: transparent }
@@ -444,7 +444,7 @@ Parsing an extremely small loadable file</span></b></font></p>
 </p>
 <p style="line-height: 100%; margin-bottom: 0cm"><span style="font-style: normal"><span style="font-weight: normal">1</span></span><span style="font-style: normal"><span style="font-weight: normal">
 An interpreter shall parse an </span></span><i><span style="font-weight: normal">extremely
-small executable</span></i><span style="font-style: normal"><span style="font-weight: normal">
+small </span></i><i><span style="font-weight: normal">loadable</span></i><span style="font-style: normal"><span style="font-weight: normal">
 file in the following steps:</span></span></p>
 <ul>
 	<li><p style="line-height: 100%; margin-bottom: 0cm"><span style="font-style: normal"><span style="font-weight: normal">The


### PR DESCRIPTION
Section 3.2p1 said "An interpreter [...] extremely small **executable** file [...]", while the emphasized text should've been **loadable**.